### PR TITLE
Allow SPC, TAB and RET as wrapper

### DIFF
--- a/features/wrap-region.feature
+++ b/features/wrap-region.feature
@@ -39,3 +39,53 @@ Feature: Wrap Region
     Then I should not see "this (is some) text"
     But I should see "this (is some text"
 
+  Scenario: Wrap with SPC
+    Given I add wrapper " / "
+    And I turn on wrap-region globally
+    When I open temp file "global"
+    And I insert "Thisis sometext"
+    And I select "is some"
+    And I press "SPC"
+    Then I should see "This is some text"
+
+  Scenario: Wrap with TAB
+    Given I add wrapper "\t/\t"
+    And I turn on wrap-region globally
+    When I open temp file "global"
+    And I insert "Thisis sometext"
+    And I select "is some"
+    And I press "TAB"
+    Then I should see "This\tis some\ttext"
+
+  Scenario: Wrap with RET
+    Given I add wrapper "\n/\n"
+    And I turn on wrap-region globally
+    When I open temp file "global"
+    And I insert "Thisis sometext"
+    And I select "is some"
+    And I press "RET"
+    Then I should see "This\nis some\ntext"
+
+  Scenario: Fallback when I have SPC wrapper
+    Given I add wrapper " / "
+    And I turn on wrap-region globally
+    When I open temp file "global"
+    And I insert "This is some text"
+    And I press "SPC"
+    Then I should see "This is some text "
+
+  Scenario: Fallback when I have TAB wrapper
+    Given I add wrapper "\t/\t"
+    And I turn on wrap-region globally
+    When I open temp file "global"
+    And I insert "This is some text"
+    And I press "TAB"
+    Then I should see "This is some text\t"
+
+  Scenario: Fallback when I have RET wrapper
+    Given I add wrapper "\n/\n"
+    And I turn on wrap-region globally
+    When I open temp file "global"
+    And I insert "Thisis sometext"
+    And I press "RET"
+    Then I should see "This is some text\n"

--- a/wrap-region.el
+++ b/wrap-region.el
@@ -164,7 +164,14 @@
   (let ((wrap-region-mode nil))
     (call-interactively
      (key-binding
-      (read-kbd-macro key)))))
+      (wrap-region-read-kbd-macro key)))))
+
+(defun wrap-region-read-kbd-macro (key)
+  (setq key (cond ((equal key " " )  "SPC")
+                  ((equal key "\t") "TAB")
+                  ((equal key "\n") "RET")
+                  (t key)))
+  (read-kbd-macro key))
 
 (defun wrap-region-add-wrappers (wrappers)
   "Add WRAPPERS by calling `wrap-region-add-wrapper' for each one."
@@ -273,7 +280,7 @@ If MODE-OR-MODES is not present, all wrappers for KEY are removed."
 
 (defun wrap-region-define-key (key &optional fn)
   "Binds KEY to FN in `wrap-region-mode-map'."
-  (define-key wrap-region-mode-map (read-kbd-macro key) fn))
+  (define-key wrap-region-mode-map (wrap-region-read-kbd-macro key) fn))
 
 
 ;;;###autoload


### PR DESCRIPTION
The tests for SPC pass but TAB and RET fail. I think it is because the way I wrote the tests is wrong or there is a bug in espuds-text.el.

Thanks in advance!
