### PR TITLE
Add customize interface

### DIFF
--- a/wrap-region.el
+++ b/wrap-region.el
@@ -98,6 +98,7 @@
   :group 'wrap-region
   :type '(repeat (symbol :tag "Major mode")))
 
+(define-obsolete-variable-alias 'wrap-region-hook 'wrap-region-mode-hook "0.8")
 (defcustom wrap-region-mode-hook nil
   "Functions to run after `wrap-region-mode' is enabled.
 


### PR DESCRIPTION
Make Wrap Region customizable via `M-x customize-group` and friends.
- The first commit removes `wrap-region-hook`, which I considered superfluous given that any minor mode from `define-minor-mode` implicitly runs `-mode-hook` anyway.  Is there a special reason for this extra hook?
- The second commit adds the necessary custom declarations.
