### PR TITLE
Remove quotes of wrap-region-add-wrappers

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -35,9 +35,9 @@ The same can be done with:
     (wrap-region-add-wrappers
      '(("$" "$")
        ("{-" "-}" "#")
-       ("/" "/" nil 'ruby-mode)
-       ("/* " " */" "#" '(java-mode javascript-mode css-mode))
-       ("`" "`" nil '(markdown-mode ruby-mode))))
+       ("/" "/" nil ruby-mode)
+       ("/* " " */" "#" (java-mode javascript-mode css-mode))
+       ("`" "`" nil (markdown-mode ruby-mode))))
 
 
 For more information, see comments in `wrap-region.el`.


### PR DESCRIPTION
I was confused about the example in the README.
Modes list with quote doesn't work.
