### PR TITLE
Move cursor to the correct position after inserting right part

### DIFF
--- a/wrap-region.el
+++ b/wrap-region.el
@@ -199,7 +199,7 @@ If nil, always wrap the region."
       (insert left)
       (goto-char (+ end (length left)))
       (insert right))
-    (if (= pos end) (forward-char 1))
+    (if (= pos end) (forward-char (length right)))
     (if wrap-region-keep-mark
         (let* ((beg-p (eq beg pos))
                (beg* (+ beg (length left)))


### PR DESCRIPTION
After inserting the right part of the wrapper, the cursor should move as many chars as has been inserted, not just 1.

This is a fix for issue #15 when the wrapper consists of multiple chars like ``hello'' in latex.
